### PR TITLE
Update _watershed.py

### DIFF
--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -104,8 +104,7 @@ def watershed(image, markers=None, connectivity=1, offset=None, mask=None,
     offset : array_like of shape image.ndim, optional
         offset of the connectivity (one offset per dimension)
     mask : ndarray of bools or 0s and 1s, optional
-        Array of same shape as `image`. Only points at which mask == True
-        will be labeled.
+        Array of same shape as image. Defaults to ndarray of 1s. May be used to restrict labeling to thresholded regions (see Examples section).
     compactness : float, optional
         Use compact watershed [3]_ with given compactness parameter.
         Higher values result in more regularly-shaped watershed basins.


### PR DESCRIPTION
update segmentation.watershed documentation to clarify use of mask argument

## Description
I find the current [documentation](https://github.com/scikit-image/scikit-image/blob/main/skimage/segmentation/_watershed.py) for the watershed segmentation function could be improved.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Release note
```release-note
Argument description is changed from
old: "Array of same shape as image. Only points at which mask == True will be labeled."
to
new: "Array of same shape as image. Defaults to ndarray of 1s. May be used to restrict labeling to thresholded regions (see Examples section)."
...
```
